### PR TITLE
Allow optional display of buffer substring when previewing marks.

### DIFF
--- a/README.org
+++ b/README.org
@@ -72,6 +72,15 @@
            evil-owl-separator          "\n")
    #+END_SRC
 
+   For ~evil-owl-local-mark-format~ and ~evil-owl-global-mark-format~,
+   a preview of the line corresponding to the stored mark can be
+   viewed using something like the following:
+
+   #+BEGIN_SRC emacs-lisp
+     (setq evil-owl-local-mark-format " %m: [l: %-5l, c: %-5c]\n    %s")
+     (setq evil-owl-global-mark-format " %m: [l: %-5l, c: %-5c] %b\n    %s")
+   #+END_SRC
+
    ~evil-owl-register-groups~ and ~evil-owl-mark-groups~ determine
    register and mark groups, respectively, for display.
 

--- a/evil-owl.el
+++ b/evil-owl.el
@@ -96,7 +96,8 @@ Possible format specifiers are:
 - %m: the mark
 - %l: the mark's line number
 - %c: the mark's column number
-- %b: the mark's buffer"
+- %b: the mark's buffer
+- %s: text of the mark's line"
   :type 'string)
 
 (defcustom evil-owl-global-mark-format " %m: [l: %-5l, c: %-5c] %b"
@@ -105,7 +106,8 @@ Possible format specifiers are:
 - %m: the mark
 - %l: the mark's line number
 - %c: the mark's column number
-- %b: the mark's buffer"
+- %b: the mark's buffer
+- %s: text of the mark's line"
   :type 'string)
 
 (defcustom evil-owl-separator "\n"
@@ -125,9 +127,11 @@ The value may be either 'window or 'posframe."
   "The idle delay, in seconds, before the popup appears."
   :type 'float)
 
-(defcustom evil-owl-register-char-limit nil
-  "Maximum number of characters to consider in a string register."
+(defcustom evil-owl-max-string-length nil
+  "Maximum number of characters to consider in a string register or context line."
   :type 'integer)
+
+(define-obsolete-variable-alias 'evil-owl-register-char-limit 'evil-owl-max-string-length "0.0.1")
 
 (defcustom evil-owl-lighter " evil-owl"
   "Lighter for evil-owl."
@@ -171,9 +175,9 @@ The result is nil if REG is empty."
   (when-let ((contents (evil-get-register reg t)))
     (cond
      ((stringp contents)
-      (when (and evil-owl-register-char-limit
-                 (> (length contents) evil-owl-register-char-limit))
-        (setq contents (substring contents 0 evil-owl-register-char-limit)))
+      (when (and evil-owl-max-string-length
+                 (> (length contents) evil-owl-max-string-length))
+        (setq contents (substring contents 0 evil-owl-max-string-length)))
       (replace-regexp-in-string "\n" "^J" contents))
      ((vectorp contents)
       (key-description contents)))))
@@ -212,16 +216,23 @@ MARK points nowhere."
              (buffer (cond ((numberp pos) (current-buffer))
                            ((markerp pos) (marker-buffer pos)))))
     (with-current-buffer buffer
-      (let ((line (line-number-at-pos pos))
-            (column (save-excursion
-                      (goto-char pos)
-                      (current-column))))
-        (list line column (current-buffer))))))
+      (save-excursion
+        (goto-char pos)
+        (let* ((line (line-number-at-pos pos))
+               (column (current-column))
+               (context-beg (line-beginning-position))
+               (context-end (if evil-owl-max-string-length
+                                (min (+ context-beg
+                                        evil-owl-max-string-length)
+                                     (line-end-position))
+                              (line-end-position)))
+               (context (buffer-substring context-beg context-end)))
+          (list line column buffer context))))))
 
 (defun evil-owl--mark-entry-string (mark)
   "Compute the entry string for MARK."
   (if-let ((pos-info (evil-owl--get-mark mark)))
-      (cl-destructuring-bind (line column buffer) pos-info
+      (cl-destructuring-bind (line column buffer contents) pos-info
         (let ((format (if (evil-owl--global-marker-p mark)
                           evil-owl-global-mark-format
                         evil-owl-local-mark-format))
@@ -229,6 +240,7 @@ MARK points nowhere."
                                                      'face 'evil-owl-entry-name)
                                       ?l line
                                       ?c column
+                                      ?s contents
                                       ?b buffer)))
           (concat (format-spec format spec) "\n")))
     ""))

--- a/test/evil-owl-test.el
+++ b/test/evil-owl-test.el
@@ -155,7 +155,43 @@ Special
  }: [l: 4    , c: 0    ]
 "))
           "as[d]f\njkl;\nemacs\n\nline\nowl\n")
-        "asdf\nfdsa\nelisp\n[]"))))
+        "asdf\nfdsa\nelisp\n[]")))
+  (ert-info ("Display context lines")
+    (evil-owl--with-test-env
+     (let ((evil-owl-local-mark-format " %m: [l: %-5l, c: %-5c]\n    %s")
+           (evil-owl-global-mark-format " %m: [l: %-5l, c: %-5c] %b\n    %s"))
+       (evil-test-buffer
+        "asdf\nfds[a]\nelisp\n"
+        (rename-buffer " *evil-owl-test*")
+        ("mB" "G" "mP")
+        (evil-test-buffer
+         "asdf\n[j]kl;\nline\nowl\n"
+         ("ma" "j" "iemacs" [return] [return] [escape] "gg2l" "m0")
+         (should (equal (evil-owl--mark-display-string)
+                        "Named Local
+ a: [l: 2    , c: 0    ]
+    jkl;
+
+Named Global
+ B: [l: 2    , c: 3    ]  *evil-owl-test*
+    fdsa
+ P: [l: 4    , c: 0    ]  *evil-owl-test*
+    
+
+Numbered
+ 0: [l: 1    , c: 2    ]
+    asdf
+
+Special
+ ^: [l: 5    , c: 0    ]
+    line
+ {: [l: 1    , c: 0    ]
+    asdf
+ }: [l: 4    , c: 0    ]
+    
+"))
+         "as[d]f\njkl;\nemacs\n\nline\nowl\n")
+        "asdf\nfdsa\nelisp\n[]")))))
 
 (ert-deftest evil-owl-test-register-commands ()
   "Check that evil-owl's register commands function normally."


### PR DESCRIPTION
I think it might be useful to have a text preview of what mark you're trying to jump to when pressing `'`.

edit: Oh, I didn't notice there were tests. Sorry, I'll try to fix.