### PR TITLE
Preserve menu bar, tool bar, and tab bar

### DIFF
--- a/evil-owl.el
+++ b/evil-owl.el
@@ -366,7 +366,15 @@ The popup type is determined by `evil-owl-display-method'."
            (,current-global-map (current-global-map)))
        (unwind-protect
            (progn
-             (use-global-map (make-sparse-keymap))
+             (use-global-map
+              (let ((map (make-sparse-keymap)))
+                (define-key map [menu-bar]
+                  (lookup-key global-map [menu-bar]))
+                (define-key map [tool-bar]
+                  (lookup-key global-map [tool-bar]))
+                (define-key map [tab-bar]
+                  (lookup-key global-map [tab-bar]))
+                map))
              ,@body)
          (use-global-map ,current-global-map)))))
 


### PR DESCRIPTION
When setting a new global map, the entries for the menu bar, tool bar, and tab bar must be copied to the new map from the old one to avoid hiding the bars.

Before this change, evil-owl's popup would hide these bars when it was opened, and the tab bar was not restored when the popup was closed.  After this change, none of the bars are hidden.

* `evil-owl.el` (`evil-owl--with-popup-map`): Copy the old global map's `menu-bar`, `tool-bar`, and `tab-bar` entries to the new map.