### PR TITLE
Remove broken &rest from evil-define-command.

### DIFF
--- a/evil-owl.el
+++ b/evil-owl.el
@@ -416,12 +416,12 @@ DISPLAY is a function that outputs a string to show in the preview
 popup."
   (declare (indent defun))
   (let ((args (cl-gensym "args")))
-    `(evil-define-command ,name (&rest ,args)
+    `(evil-define-command ,name (,args)
        ,(format "Wrapper function for `%s' that shows a preview popup." wrap)
        ,@(evil-get-command-properties wrap)
        (interactive (evil-owl--eval-interactive-spec #',wrap #',display))
        (setq this-command #',wrap)
-       (apply #'funcall-interactively #',wrap ,args))))
+       (apply #'funcall-interactively #',wrap ,args nil))))
 
 (evil-owl--define-wrapper evil-owl-use-register
   :wrap evil-use-register


### PR DESCRIPTION
Also add a nil after the args to cheat the args through the apply. There's probably a better way of doing that, but elisp ain't my mother tongue.

Fixes #4 for at least: evil-owl-record-macro, evil-owl-set-marker, evil-owl-goto-mark, and evil-owl-paste-from-register.